### PR TITLE
meta: bundle nbtp library via Git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "nbtp"]
+	path = nbtp
+	url = https://git.cth451.me/cth451/nbtp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,6 @@ set (Minemap_VERSION_MAJOR 0)
 set (Minemap_VERSION_MINOR 2)
 
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(NBTP REQUIRED nbtp)
 find_package(Boost REQUIRED COMPONENTS iostreams filesystem)
 pkg_check_modules(ImageMagick REQUIRED Magick++-7.Q16HDRI)
 
@@ -17,6 +16,11 @@ option(BUILD_PAMENIM "Build Pamenim" ON)
 
 set(MINEMAP_PALETTE_DIR ${CMAKE_INSTALL_PREFIX}/share/minemap/palettes CACHE STRING "Directory to minemap palette GIFs")
 add_compile_definitions(MINEMAP_PALETTE_DIR=\"${MINEMAP_PALETTE_DIR}\")
+
+# External imports
+option(NBTP_BUILD_PYTHON_MODULE OFF)
+add_subdirectory(nbtp EXCLUDE_FROM_ALL)
+target_include_directories(nbtp INTERFACE ./nbtp/include)
 
 # Source files
 add_subdirectory(src)

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ This repository contains two command line utilities, "minemap" to convert images
 
 Building is handled by CMake. Please make sure you have the following dependencies:
 
-* [libnbtp](https://git.cth451.me/cth451/nbtp), my nbt manipulation and parsing library
 * boost libraries with headers
 * Magick++ 7, part of Imagemagick
+
+Prior to building, please run `git submodule update --init --recursive`.
 
 ### Building on Windows...
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,14 +5,13 @@ add_executable(minemap
         ColorMap.cpp
         constants.h)
 
-target_link_libraries(minemap PUBLIC ${NBTP_LIBRARIES})
+target_link_libraries(minemap PUBLIC nbtp)
 target_link_libraries(minemap PUBLIC ${ImageMagick_LIBRARIES})
 target_link_libraries(minemap PUBLIC ${Boost_LIBRARIES})
 if (UNIX)
     target_link_libraries(minemap PUBLIC dl)
 endif()
 
-target_include_directories(minemap PUBLIC ${NBTP_INCLUDE_DIRS})
 target_include_directories(minemap PUBLIC ${ImageMagick_INCLUDE_DIRS})
 target_include_directories(minemap PUBLIC ${Boost_INCLUDE_DIRS})
 
@@ -26,13 +25,12 @@ if (BUILD_PAMENIM)
             VersionSpec.cpp
             ColorMap.cpp
             constants.h)
-    target_link_libraries(pamenim PUBLIC ${NBTP_LIBRARIES})
+    target_link_libraries(pamenim PUBLIC nbtp)
     target_link_libraries(pamenim PUBLIC ${ImageMagick_LIBRARIES})
     target_link_libraries(pamenim PUBLIC ${Boost_LIBRARIES})
     if (UNIX)
         target_link_libraries(pamenim PUBLIC dl)
     endif()
-    target_include_directories(pamenim PUBLIC ${NBTP_INCLUDE_DIRS})
     target_include_directories(pamenim PUBLIC ${ImageMagick_INCLUDE_DIRS})
     target_include_directories(pamenim PUBLIC ${Boost_INCLUDE_DIRS})
 


### PR DESCRIPTION
Bundle the `nbtp` library and build the library in-place with `minemap`.