### PR TITLE
CI: build Windows binaries

### DIFF
--- a/.ci/linux-mingw.sh
+++ b/.ci/linux-mingw.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -e
+
+sudo apt-get update
+sudo apt-get install -y gpg wget git python3-pip ccache p7zip-full g++-mingw-w64-x86-64 gcc-mingw-w64-x86-64 mingw-w64-tools cmake ninja-build
+
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+export VCPKG_ROOT="$PWD"
+./bootstrap-vcpkg.sh
+./vcpkg version
+
+export VCPKG_DEFAULT_TRIPLET=x64-mingw-static
+export VCPKG_DEFAULT_HOST_TRIPLET=x64-linux
+export VCPKG_BINARY_SOURCES=files,"$HOME"/.vcpkg,readwrite
+patch -Np1 -i ../cmake/graphicsmagic-mingw-w64.patch
+
+./vcpkg install fmt zlib jbigkit graphicsmagick
+cd ..
+
+mkdir -p build && cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release -GNinja \
+         -DSYSTEM_NBTP=OFF \
+         -DCMAKE_INSTALL_PREFIX=/ \
+         -DUSE_GRAPHICSMAGICK=ON \
+         -DUSE_CCACHE=ON \
+         -DCMAKE_TOOLCHAIN_FILE="${VCPKG_ROOT}"/scripts/buildsystems/vcpkg.cmake \
+         -DVCPKG_TARGET_TRIPLET=x64-mingw-static \
+         -DVCPKG_CHAINLOAD_TOOLCHAIN_FILE="$PWD"/../cmake/MinGWCross.cmake
+
+export DESTDIR="$PWD"/dist
+export ARTIFACTDIR="$PWD"/../package
+mkdir -p "${ARTIFACTDIR}"
+DESTDIR="${DESTDIR}" ninja install
+
+cd dist/
+ARCHIVE_NAME=minemap-win64
+7za a -tzip "${ARTIFACTDIR}/${ARCHIVE_NAME}.zip" .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: 'CI'
+
+on:
+  push:
+    branches: [ "*" ]
+    tags: [ "*" ]
+  pull_request:
+    branches: [ master ]
+
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Set up cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.ccache
+            ~/.vcpkg
+          key: ${{ runner.os }}-win-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-win-
+      - run: ./.ci/linux-mingw.sh
+        name: 'Build Windows binaries'
+      - name: Upload
+        uses: actions/upload-artifact@v3
+        with:
+          name: mingw
+          path: package/

--- a/cmake/MinGWCross.cmake
+++ b/cmake/MinGWCross.cmake
@@ -1,0 +1,52 @@
+SET(MINGW_PREFIX   /usr/x86_64-w64-mingw32/)
+SET(CMAKE_SYSTEM_NAME               Windows)
+SET(CMAKE_SYSTEM_PROCESSOR           x86_64)
+# Actually a hack, w/o this will cause some strange errors
+SET(CMAKE_HOST_WIN32                 TRUE)
+
+
+SET(CMAKE_FIND_ROOT_PATH            ${MINGW_PREFIX})
+SET(SDL2_PATH                       ${MINGW_PREFIX})
+SET(MINGW_TOOL_PREFIX               ${CMAKE_SYSTEM_PROCESSOR}-w64-mingw32-)
+
+# Specify the cross compiler
+SET(CMAKE_C_COMPILER            ${MINGW_TOOL_PREFIX}gcc)
+SET(CMAKE_CXX_COMPILER          ${MINGW_TOOL_PREFIX}g++)
+SET(CMAKE_RC_COMPILER           ${MINGW_TOOL_PREFIX}windres)
+
+# Mingw tools
+SET(STRIP                       ${MINGW_TOOL_PREFIX}strip)
+SET(WINDRES                     ${MINGW_TOOL_PREFIX}windres)
+
+# ccache wrapper
+OPTION(USE_CCACHE "Use ccache for compilation" OFF)
+IF(USE_CCACHE)
+    FIND_PROGRAM(CCACHE ccache)
+    IF (CCACHE)
+        MESSAGE(STATUS "Using ccache found in PATH")
+        SET_PROPERTY(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${CCACHE})
+        SET_PROPERTY(GLOBAL PROPERTY RULE_LAUNCH_LINK ${CCACHE})
+    ELSE(CCACHE)
+        MESSAGE(WARNING "USE_CCACHE enabled, but no ccache found")
+    ENDIF(CCACHE)
+ENDIF(USE_CCACHE)
+
+# Search for programs in the build host directories
+SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+
+
+# Echo modified cmake vars to screen for debugging purposes
+IF(NOT DEFINED ENV{MINGW_DEBUG_INFO})
+	MESSAGE("")
+	MESSAGE("Custom cmake vars: (blank = system default)")
+	MESSAGE("-----------------------------------------")
+	MESSAGE("* CMAKE_C_COMPILER                     : ${CMAKE_C_COMPILER}")
+	MESSAGE("* CMAKE_CXX_COMPILER                   : ${CMAKE_CXX_COMPILER}")
+	MESSAGE("* CMAKE_RC_COMPILER                    : ${CMAKE_RC_COMPILER}")
+	MESSAGE("* WINDRES                              : ${WINDRES}")
+	MESSAGE("* STRIP                                : ${STRIP}")
+	MESSAGE("* USE_CCACHE                           : ${USE_CCACHE}")
+	MESSAGE("")
+	# So that the debug info only appears once
+	SET(ENV{MINGW_DEBUG_INFO} SHOWN)
+ENDIF()

--- a/cmake/graphicsmagic-mingw-w64.patch
+++ b/cmake/graphicsmagic-mingw-w64.patch
@@ -1,0 +1,13 @@
+diff --git a/ports/graphicsmagick/CMakeLists.txt b/ports/graphicsmagick/CMakeLists.txt
+index c71495951..6ee7be177 100644
+--- a/ports/graphicsmagick/CMakeLists.txt
++++ b/ports/graphicsmagick/CMakeLists.txt
+@@ -12,6 +12,8 @@ add_definitions(-D_MAGICKLIB_ -D_WANDLIB_ -DMAGICK_IMPLEMENTATION)
+ 
+ if (BUILD_SHARED_LIBS)
+     add_definitions(-D_DLL -DDLL)
++else ()
++    add_definitions(-D_LIB)
+ endif ()
+ 
+ if (MSVC)


### PR DESCRIPTION
Use Linux CI to build Windows binaries. Currently does not support publishing releases.